### PR TITLE
Update the namespace and add interactive facade

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,4 @@
-blank_issues_enabled: false
+blank_issues_enabled: true
 contact_links:
   - name: Ask a question
     url: https://github.com/Binary Cats/rbac/discussions/new?category=q-a

--- a/README.md
+++ b/README.md
@@ -4,15 +4,15 @@
 [![run-tests](https://github.com/binary-cats/rbac/actions/workflows/run-tests.yml/badge.svg)](https://github.com/binary-cats/rbac/actions/workflows/run-tests.yml)
 [![GitHub Code Style Action Status](https://github.styleci.io/repos/773171043/shield?branch=main&style=flat-square)](https://github.com/binary-cats/rbac/actions?query=workflow%3A"Fix+PHP+code+style+issues"+branch%3Amain)
 
-Opinionated extension for [spatie/laravel-permissions](https://spatie.be/docs/laravel-permission/v6/introduction).
-When your permission list grows and maintenance becomes an issue, this package offers simple way of defining roles and their permissions.  
+Enhance Laravel 11 with opinionated extension for [spatie/laravel-permissions](https://spatie.be/docs/laravel-permission/v6/introduction).
+Before your permission list grows and maintenance becomes an issue, this package offers simple way of defining roles and their permissions.  
 
 ## Installation
 
 You can install the package via composer:
 
 ```bash
-composer require binary-cats/rbac
+composer require binary-cats/laravel-rbac
 ```
 
 You can publish the config file with:
@@ -35,9 +35,9 @@ return [
     */
 
     'jobs' => [
-        \BinaryCats\Rbac\Jobs\FlushPermissionCache::class,
-        \BinaryCats\Rbac\Jobs\ResetPermissions::class,
-        \BinaryCats\Rbac\Jobs\SyncDefinedRoles::class,
+        \BinaryCats\LaravelRbac\Jobs\FlushPermissionCache::class,
+        \BinaryCats\LaravelRbac\Jobs\ResetPermissions::class,
+        \BinaryCats\LaravelRbac\Jobs\SyncDefinedRoles::class,
     ],
 
     /*
@@ -74,7 +74,13 @@ php artisan rbac:reset
 In a simple setup we usually have two basic parts of an RBAC: a permission and a role. 
 Permissions are usually grouped by functional or business logic domain and a Role encapsulates them for a specific guard.
 
-To avoid collision with `spatie/laravel-permission` we are going to use `BackedEnum` Ability to hold out enumerated permissions:
+1. [Create Abilities](#abilities)
+2. [Define Roles](#defined-roles)
+3. [Connect the dots](#connect-the-dots)
+
+### Abilities
+
+To avoid collision with `spatie/laravel-permission` we are going to use `BackedEnum` Ability enums to hold out enumerated permissions:
 You can read more on using `enums` as permissions at the [official docs](https://spatie.be/docs/laravel-permission/v6/basic-usage/enums). 
 
 To create an Ability: 
@@ -111,7 +117,7 @@ php artisan make:role EditorRole
 This will generate an `EditorRole` within `App\Roles`:
 
 ```php
-use BinaryCats\Rbac\DefinedRole;
+use BinaryCats\LaravelRbac\DefinedRole;
 
 class EditorRole extends DefinedRole
 {
@@ -136,8 +142,10 @@ This class contains a (now testable!) configuration definition for the role and 
 We can now adjust it like so:
 
 ```php
+namespace App\Roles;
+
 use App\Abilities\PostAbility;
-use BinaryCats\Rbac\DefinedRole;
+use BinaryCats\LaravelRbac\DefinedRole;
 
 class EditorRole extends DefinedRole
 {
@@ -162,6 +170,19 @@ class EditorRole extends DefinedRole
 }
 ```
 Now you are confident a specific role has specific permissions!
+
+### Connect the dots
+
+Now that we have the abilities and roles, simply register role with `rbac.php` config:
+
+```php
+    'roles' => [
+        \App\Roles\EditorRole::class,
+        ...
+    ],
+```
+
+When you run `rbac:reset` next time, your RBAC will be reset automatically.
 
 ## Integration
 

--- a/composer.json
+++ b/composer.json
@@ -31,12 +31,12 @@
     },
     "autoload": {
         "psr-4": {
-            "BinaryCats\\Rbac\\": "src/"
+            "BinaryCats\\LaravelRbac\\": "src/"
         }
     },
     "autoload-dev": {
         "psr-4": {
-            "BinaryCats\\Rbac\\Tests\\": "tests/"
+            "BinaryCats\\LaravelRbac\\Tests\\": "tests/"
         }
     },
     "suggest": {
@@ -52,10 +52,10 @@
     "extra": {
         "laravel": {
             "providers": [
-                "BinaryCats\\Rbac\\RbacServiceProvider"
+                "BinaryCats\\LaravelRbac\\RbacServiceProvider"
             ],
             "aliases": {
-                "Rbac": "BinaryCats\\Rbac\\Facades\\Rbac"
+                "Rbac": "BinaryCats\\LaravelRbac\\Facades\\Rbac"
             }
        },
         "branch-alias": {

--- a/composer.json
+++ b/composer.json
@@ -1,13 +1,13 @@
 {
-    "name": "binary-cats/rbac",
-    "description": "Enum-backed RBAC extension of spatie/laravel-permission",
+    "name": "binary-cats/laravel-rbac",
+    "description": "Laravel 11 enum-backed RBAC extension of spatie/laravel-permission",
     "keywords": [
         "binary-cats",
         "enum",
         "laravel",
         "rbac"
     ],
-    "homepage": "https://github.com/binary-cats/rbac",
+    "homepage": "https://github.com/binary-cats/laravel-rbac",
     "license": "MIT",
     "authors": [
         {
@@ -31,14 +31,17 @@
     },
     "autoload": {
         "psr-4": {
-            "BinaryCats\\Rbac\\": "src/",
-            "BinaryCats\\Rbac\\Database\\Factories\\": "database/factories/"
+            "BinaryCats\\Rbac\\": "src/"
         }
     },
     "autoload-dev": {
         "psr-4": {
             "BinaryCats\\Rbac\\Tests\\": "tests/"
         }
+    },
+    "suggest": {
+        "binary-cats/laravel-mailgun-webhooks": "Handle Mailgun webhooks in your Laravel application",
+        "binary-cats/laravel-sku": "Generate SKUs for Eloquent models"
     },
     "scripts": {
         "test": "vendor/bin/phpunit"

--- a/config/rbac.php
+++ b/config/rbac.php
@@ -1,7 +1,5 @@
 <?php
 
-use App\Enums\Ability;
-
 return [
 
     /*

--- a/config/rbac.php
+++ b/config/rbac.php
@@ -12,9 +12,9 @@ return [
     */
 
     'jobs' => [
-        \BinaryCats\Rbac\Jobs\FlushPermissionCache::class,
-        \BinaryCats\Rbac\Jobs\ResetPermissions::class,
-        \BinaryCats\Rbac\Jobs\SyncDefinedRoles::class,
+        \BinaryCats\LaravelRbac\Jobs\FlushPermissionCache::class,
+        \BinaryCats\LaravelRbac\Jobs\ResetPermissions::class,
+        \BinaryCats\LaravelRbac\Jobs\SyncDefinedRoles::class,
     ],
 
     /*

--- a/src/Actions/StorePermission.php
+++ b/src/Actions/StorePermission.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace BinaryCats\Rbac\Actions;
+namespace BinaryCats\LaravelRbac\Actions;
 
 use BackedEnum;
 use Illuminate\Support\Facades\Artisan;

--- a/src/Actions/SyncDefinedRole.php
+++ b/src/Actions/SyncDefinedRole.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace BinaryCats\Rbac\Actions;
+namespace BinaryCats\LaravelRbac\Actions;
 
 use BackedEnum;
 use Illuminate\Support\Facades\Artisan;

--- a/src/Commands/AbilityMakeCommand.php
+++ b/src/Commands/AbilityMakeCommand.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace BinaryCats\Rbac\Commands;
+namespace BinaryCats\LaravelRbac\Commands;
 
 use Illuminate\Console\Concerns\CreatesMatchingTest;
 use Illuminate\Console\GeneratorCommand;

--- a/src/Commands/DefinedRoleMakeCommand.php
+++ b/src/Commands/DefinedRoleMakeCommand.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace BinaryCats\Rbac\Commands;
+namespace BinaryCats\LaravelRbac\Commands;
 
 use Illuminate\Console\Concerns\CreatesMatchingTest;
 use Illuminate\Console\GeneratorCommand;

--- a/src/Commands/RbacResetCommand.php
+++ b/src/Commands/RbacResetCommand.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace BinaryCats\Rbac\Commands;
+namespace BinaryCats\LaravelRbac\Commands;
 
 use Illuminate\Console\Command;
 use Illuminate\Support\Collection;

--- a/src/Contracts/DefinedRole.php
+++ b/src/Contracts/DefinedRole.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace BinaryCats\Rbac\Contracts;
+namespace BinaryCats\LaravelRbac\Contracts;
 
 interface DefinedRole
 {

--- a/src/DefinedRole.php
+++ b/src/DefinedRole.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace BinaryCats\Rbac;
+namespace BinaryCats\LaravelRbac;
 
-use BinaryCats\Rbac\Actions\SyncDefinedRole;
-use BinaryCats\Rbac\Contracts\DefinedRole as DefinedRoleContract;
+use BinaryCats\LaravelRbac\Actions\SyncDefinedRole;
+use BinaryCats\LaravelRbac\Contracts\DefinedRole as DefinedRoleContract;
 use Illuminate\Support\Str;
 use ReflectionClass;
 

--- a/src/DiscoverAbilities.php
+++ b/src/DiscoverAbilities.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace BinaryCats\Rbac;
+namespace BinaryCats\LaravelRbac;
 
-use BinaryCats\Rbac\Exceptions\RbacException;
+use BinaryCats\LaravelRbac\Exceptions\RbacException;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use ReflectionClass;

--- a/src/Exceptions/RbacException.php
+++ b/src/Exceptions/RbacException.php
@@ -4,16 +4,25 @@ namespace BinaryCats\Rbac\Exceptions;
 
 use BackedEnum;
 use Exception;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 
 class RbacException extends Exception
 {
-    public static function rbacContainsDuplicateAbilities($abilities): static
+    /**
+     * @param \Illuminate\Support\Collection $abilities
+     * @return static
+     */
+    public static function rbacContainsDuplicateAbilities(Collection $abilities): static
     {
         $duplicates = $abilities
             ->groupBy('value')
-            ->filter(fn ($element) => $element->count() > 2)
-            ->map(fn (BackedEnum $enum) => Str::of(get_class($enum))->append(':', $enum->value));
+            ->filter(fn ($element) => $element->count() > 1)
+            ->collapse()
+            ->map(fn(BackedEnum $enum) => Str::of(get_class($enum))
+                ->classBasename()
+                ->append(':', $enum->value)
+            );
 
         $message = __('The following RBAC abilities are duplicated [:duplicates]', [
             'duplicates' => $duplicates->implode(', '),

--- a/src/Exceptions/RbacException.php
+++ b/src/Exceptions/RbacException.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace BinaryCats\Rbac\Exceptions;
+namespace BinaryCats\LaravelRbac\Exceptions;
 
 use BackedEnum;
 use Exception;

--- a/src/Facades/Rbac.php
+++ b/src/Facades/Rbac.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace BinaryCats\Rbac\Facades;
+
+use Illuminate\Support\Facades\Facade;
+
+class Rbac extends Facade
+{
+    protected static function getFacadeAccessor()
+    {
+        return \BinaryCats\Rbac\Rbac::class;
+    }
+}

--- a/src/Facades/Rbac.php
+++ b/src/Facades/Rbac.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace BinaryCats\Rbac\Facades;
+namespace BinaryCats\LaravelRbac\Facades;
 
 use Illuminate\Support\Facades\Facade;
 
@@ -8,6 +8,6 @@ class Rbac extends Facade
 {
     protected static function getFacadeAccessor()
     {
-        return \BinaryCats\Rbac\Rbac::class;
+        return \BinaryCats\LaravelRbac\Rbac::class;
     }
 }

--- a/src/Jobs/FlushPermissionCache.php
+++ b/src/Jobs/FlushPermissionCache.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace BinaryCats\Rbac\Jobs;
+namespace BinaryCats\LaravelRbac\Jobs;
 
 use Illuminate\Bus\Queueable;
 use Illuminate\Foundation\Bus\Dispatchable;

--- a/src/Jobs/ResetPermissions.php
+++ b/src/Jobs/ResetPermissions.php
@@ -5,6 +5,7 @@ namespace BinaryCats\Rbac\Jobs;
 use BackedEnum;
 use BinaryCats\Rbac\Actions\StorePermission;
 use BinaryCats\Rbac\DiscoverAbilities;
+use BinaryCats\Rbac\Facades\Rbac;
 use Illuminate\Bus\Queueable;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
@@ -19,14 +20,12 @@ class ResetPermissions
     use SerializesModels;
 
     protected string $guard;
-    protected string $abilityPath;
 
     /**
      * @param string|null $guard
      */
     public function __construct(string $guard = null)
     {
-        $this->abilityPath = config('rbac.path');
         $this->guard = $guard ?? config('auth.defaults.guard');
     }
 
@@ -44,9 +43,6 @@ class ResetPermissions
      */
     protected function permissions(): Collection
     {
-        return DiscoverAbilities::within(
-            abilitiesPath: $this->abilityPath,
-            basePath: app()->basePath()
-        );
+        return Rbac::abilities();
     }
 }

--- a/src/Jobs/ResetPermissions.php
+++ b/src/Jobs/ResetPermissions.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace BinaryCats\Rbac\Jobs;
+namespace BinaryCats\LaravelRbac\Jobs;
 
 use BackedEnum;
-use BinaryCats\Rbac\Actions\StorePermission;
-use BinaryCats\Rbac\DiscoverAbilities;
-use BinaryCats\Rbac\Facades\Rbac;
+use BinaryCats\LaravelRbac\Actions\StorePermission;
+use BinaryCats\LaravelRbac\DiscoverAbilities;
+use BinaryCats\LaravelRbac\Facades\Rbac;
 use Illuminate\Bus\Queueable;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;

--- a/src/Jobs/SyncDefinedRoles.php
+++ b/src/Jobs/SyncDefinedRoles.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace BinaryCats\Rbac\Jobs;
+namespace BinaryCats\LaravelRbac\Jobs;
 
-use BinaryCats\Rbac\Contracts\DefinedRole;
+use BinaryCats\LaravelRbac\Contracts\DefinedRole;
 use Illuminate\Bus\Queueable;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;

--- a/src/Rbac.php
+++ b/src/Rbac.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace BinaryCats\Rbac;
+
+use Illuminate\Support\Collection;
+
+class Rbac
+{
+    /** @var string  */
+    protected string $abilitiesPath;
+
+    /** @var string  */
+    protected string $basePath;
+
+    /** @var \Illuminate\Support\Collection|null  */
+    protected ?Collection $abilities = null;
+
+    /**
+     * @param string $abilitiesPath
+     * @param string $basePath
+     */
+    public function __construct(string $abilitiesPath, string $basePath)
+    {
+        $this->abilitiesPath = $abilitiesPath;
+        $this->basePath = $basePath;
+    }
+
+    /**
+     * Return the list of all abilities in the application
+     */
+    public function abilities(): Collection
+    {
+        if (null === $this->abilities) {
+            $this->abilities = $this->discoverAbilities();
+        }
+
+        return $this->abilities;
+    }
+
+    /**
+     * Discover Abilities in path
+     */
+    protected function discoverAbilities(): Collection
+    {
+        return DiscoverAbilities::within(
+            abilitiesPath: $this->abilitiesPath,
+            basePath: $this->basePath
+        );
+    }
+}

--- a/src/Rbac.php
+++ b/src/Rbac.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace BinaryCats\Rbac;
+namespace BinaryCats\LaravelRbac;
 
 use Illuminate\Support\Collection;
 

--- a/src/RbacServiceProvider.php
+++ b/src/RbacServiceProvider.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace BinaryCats\Rbac;
+namespace BinaryCats\LaravelRbac;
 
-use BinaryCats\Rbac\Commands\AbilityMakeCommand;
-use BinaryCats\Rbac\Commands\DefinedRoleMakeCommand;
-use BinaryCats\Rbac\Commands\RbacResetCommand;
+use BinaryCats\LaravelRbac\Commands\AbilityMakeCommand;
+use BinaryCats\LaravelRbac\Commands\DefinedRoleMakeCommand;
+use BinaryCats\LaravelRbac\Commands\RbacResetCommand;
 use Illuminate\Contracts\Foundation\Application;
 use Spatie\LaravelPackageTools\Package;
 use Spatie\LaravelPackageTools\PackageServiceProvider;

--- a/src/RbacServiceProvider.php
+++ b/src/RbacServiceProvider.php
@@ -5,6 +5,7 @@ namespace BinaryCats\Rbac;
 use BinaryCats\Rbac\Commands\AbilityMakeCommand;
 use BinaryCats\Rbac\Commands\DefinedRoleMakeCommand;
 use BinaryCats\Rbac\Commands\RbacResetCommand;
+use Illuminate\Contracts\Foundation\Application;
 use Spatie\LaravelPackageTools\Package;
 use Spatie\LaravelPackageTools\PackageServiceProvider;
 
@@ -20,5 +21,18 @@ class RbacServiceProvider extends PackageServiceProvider
                 DefinedRoleMakeCommand::class,
                 RbacResetCommand::class,
             ]);
+    }
+
+    /**
+     * @return void
+     */
+    public function packageRegistered()
+    {
+        $this->app->bind(Rbac::class, function(Application $app) {
+            return new Rbac(
+                abilitiesPath: $app['config']->get('rbac.path'),
+                basePath: $app->basePath()
+            );
+        });
     }
 }

--- a/tests/Actions/StorePermissionTest.php
+++ b/tests/Actions/StorePermissionTest.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace BinaryCats\Rbac\Tests\Actions;
+namespace BinaryCats\LaravelRbac\Tests\Actions;
 
-use BinaryCats\Rbac\Actions\StorePermission;
-use BinaryCats\Rbac\Tests\Fixtures\Abilities\FooAbility;
-use BinaryCats\Rbac\Tests\TestCase;
+use BinaryCats\LaravelRbac\Actions\StorePermission;
+use BinaryCats\LaravelRbac\Tests\Fixtures\Abilities\FooAbility;
+use BinaryCats\LaravelRbac\Tests\TestCase;
 use Illuminate\Support\Facades\Artisan;
 use PHPUnit\Framework\Attributes\Test;
 

--- a/tests/Actions/SyncDefinedRoleTest.php
+++ b/tests/Actions/SyncDefinedRoleTest.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace BinaryCats\Rbac\Tests\Actions;
+namespace BinaryCats\LaravelRbac\Tests\Actions;
 
-use BinaryCats\Rbac\Actions\SyncDefinedRole;
-use BinaryCats\Rbac\Tests\Fixtures\Abilities\FooAbility;
-use BinaryCats\Rbac\Tests\TestCase;
+use BinaryCats\LaravelRbac\Actions\SyncDefinedRole;
+use BinaryCats\LaravelRbac\Tests\Fixtures\Abilities\FooAbility;
+use BinaryCats\LaravelRbac\Tests\TestCase;
 use Illuminate\Support\Facades\Artisan;
 use PHPUnit\Framework\Attributes\Test;
 

--- a/tests/Commands/AbilityMakeCommandTest.php
+++ b/tests/Commands/AbilityMakeCommandTest.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace BinaryCats\Rbac\Tests\Commands;
+namespace BinaryCats\LaravelRbac\Tests\Commands;
 
-use BinaryCats\Rbac\Commands\AbilityMakeCommand;
-use BinaryCats\Rbac\Tests\TestCase;
+use BinaryCats\LaravelRbac\Commands\AbilityMakeCommand;
+use BinaryCats\LaravelRbac\Tests\TestCase;
 use Illuminate\Support\Facades\File;
 use PHPUnit\Framework\Attributes\After;
 use PHPUnit\Framework\Attributes\Test;

--- a/tests/Commands/DefinedRoleMakeCommandTest.php
+++ b/tests/Commands/DefinedRoleMakeCommandTest.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace BinaryCats\Rbac\Tests\Commands;
+namespace BinaryCats\LaravelRbac\Tests\Commands;
 
-use BinaryCats\Rbac\Commands\DefinedRoleMakeCommand;
-use BinaryCats\Rbac\Tests\TestCase;
+use BinaryCats\LaravelRbac\Commands\DefinedRoleMakeCommand;
+use BinaryCats\LaravelRbac\Tests\TestCase;
 use Illuminate\Support\Facades\File;
 use PHPUnit\Framework\Attributes\After;
 use PHPUnit\Framework\Attributes\Test;

--- a/tests/Commands/RbacResetCommandTest.php
+++ b/tests/Commands/RbacResetCommandTest.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace BinaryCats\Rbac\Tests\Commands;
+namespace BinaryCats\LaravelRbac\Tests\Commands;
 
-use BinaryCats\Rbac\Commands\RbacResetCommand;
-use BinaryCats\Rbac\Tests\Fixtures\RbacResetJob;
-use BinaryCats\Rbac\Tests\TestCase;
+use BinaryCats\LaravelRbac\Commands\RbacResetCommand;
+use BinaryCats\LaravelRbac\Tests\Fixtures\RbacResetJob;
+use BinaryCats\LaravelRbac\Tests\TestCase;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Bus;
 use Illuminate\Support\Facades\Schema;

--- a/tests/DiscoverAbilitiesTest.php
+++ b/tests/DiscoverAbilitiesTest.php
@@ -3,6 +3,7 @@
 namespace BinaryCats\Rbac\Tests;
 
 use BinaryCats\Rbac\DiscoverAbilities;
+use BinaryCats\Rbac\Exceptions\RbacException;
 use BinaryCats\Rbac\Tests\Fixtures\Abilities\FooAbility;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
@@ -47,5 +48,27 @@ class DiscoverAbilitiesTest extends TestCase
         );
 
         $this->assertCount(0, $result);
+    }
+
+    #[Test]
+    public function it_will_throw_a_duplicate_exception_when_there_is_a_duplicate_permission(): void
+    {
+        DiscoverAbilities::guessClassNamesUsing(function (SplFileInfo $file, $basePath) {
+            return Str::of($file->getRealPath())
+                ->replaceFirst($basePath, '')
+                ->trim(DIRECTORY_SEPARATOR)
+                ->after('/tests/')
+                ->prepend('BinaryCats/Rbac/Tests/')
+                ->replaceLast('.php', '')
+                ->replace(DIRECTORY_SEPARATOR, '\\')
+                ->toString();
+        });
+
+        $this->expectException(RbacException::class);
+
+        DiscoverAbilities::within(
+            __DIR__.'/Fixtures/AbilitiesWithDuplicateValues',
+            __DIR__.'/../'
+        );
     }
 }

--- a/tests/DiscoverAbilitiesTest.php
+++ b/tests/DiscoverAbilitiesTest.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace BinaryCats\Rbac\Tests;
+namespace BinaryCats\LaravelRbac\Tests;
 
-use BinaryCats\Rbac\DiscoverAbilities;
-use BinaryCats\Rbac\Exceptions\RbacException;
-use BinaryCats\Rbac\Tests\Fixtures\Abilities\FooAbility;
+use BinaryCats\LaravelRbac\DiscoverAbilities;
+use BinaryCats\LaravelRbac\Exceptions\RbacException;
+use BinaryCats\LaravelRbac\Tests\Fixtures\Abilities\FooAbility;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use PHPUnit\Framework\Attributes\Test;
@@ -20,7 +20,7 @@ class DiscoverAbilitiesTest extends TestCase
                 ->replaceFirst($basePath, '')
                 ->trim(DIRECTORY_SEPARATOR)
                 ->after('/tests/')
-                ->prepend('BinaryCats/Rbac/Tests/')
+                ->prepend('BinaryCats/LaravelRbac/Tests/')
                 ->replaceLast('.php', '')
                 ->replace(DIRECTORY_SEPARATOR, '\\')
                 ->toString();
@@ -58,7 +58,7 @@ class DiscoverAbilitiesTest extends TestCase
                 ->replaceFirst($basePath, '')
                 ->trim(DIRECTORY_SEPARATOR)
                 ->after('/tests/')
-                ->prepend('BinaryCats/Rbac/Tests/')
+                ->prepend('BinaryCats/LaravelRbac/Tests/')
                 ->replaceLast('.php', '')
                 ->replace(DIRECTORY_SEPARATOR, '\\')
                 ->toString();

--- a/tests/Exceptions/RbacExceptionTest.php
+++ b/tests/Exceptions/RbacExceptionTest.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace BinaryCats\Rbac\Tests\Exceptions;
+namespace BinaryCats\LaravelRbac\Tests\Exceptions;
 
-use BinaryCats\Rbac\Exceptions\RbacException;
-use BinaryCats\Rbac\Tests\Fixtures\AbilitiesWithDuplicateValues\BatDuplicatedAbility;
-use BinaryCats\Rbac\Tests\Fixtures\AbilitiesWithDuplicateValues\FooDuplicatedAbility;
-use BinaryCats\Rbac\Tests\TestCase;
+use BinaryCats\LaravelRbac\Exceptions\RbacException;
+use BinaryCats\LaravelRbac\Tests\Fixtures\AbilitiesWithDuplicateValues\BatDuplicatedAbility;
+use BinaryCats\LaravelRbac\Tests\Fixtures\AbilitiesWithDuplicateValues\FooDuplicatedAbility;
+use BinaryCats\LaravelRbac\Tests\TestCase;
 use PHPUnit\Framework\Attributes\Test;
 
 class RbacExceptionTest extends TestCase

--- a/tests/Exceptions/RbacExceptionTest.php
+++ b/tests/Exceptions/RbacExceptionTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace BinaryCats\Rbac\Tests\Exceptions;
+
+use BinaryCats\Rbac\Exceptions\RbacException;
+use BinaryCats\Rbac\Tests\Fixtures\AbilitiesWithDuplicateValues\BatDuplicatedAbility;
+use BinaryCats\Rbac\Tests\Fixtures\AbilitiesWithDuplicateValues\FooDuplicatedAbility;
+use BinaryCats\Rbac\Tests\TestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+class RbacExceptionTest extends TestCase
+{
+    #[Test]
+    public function it_will_render_a_duplicate_exception(): void
+    {
+        $list = collect([
+            FooDuplicatedAbility::One,
+            BatDuplicatedAbility::One,
+            BatDuplicatedAbility::Tres,
+        ]);
+
+        $exception = RbacException::rbacContainsDuplicateAbilities($list);
+
+        $this->assertInstanceOf(RbacException::class, $exception);
+        $this->assertEquals(
+            'The following RBAC abilities are duplicated [FooDuplicatedAbility:una, BatDuplicatedAbility:una]',
+            $exception->getMessage()
+        );
+    }
+}

--- a/tests/Fixtures/Abilities/FooAbility.php
+++ b/tests/Fixtures/Abilities/FooAbility.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace BinaryCats\Rbac\Tests\Fixtures\Abilities;
+namespace BinaryCats\LaravelRbac\Tests\Fixtures\Abilities;
 
 enum FooAbility: string
 {

--- a/tests/Fixtures/Abilities/RandomDummyClass.php
+++ b/tests/Fixtures/Abilities/RandomDummyClass.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace BinaryCats\Rbac\Tests\Fixtures\Abilities;
+namespace BinaryCats\LaravelRbac\Tests\Fixtures\Abilities;
 
 class RandomDummyClass
 {

--- a/tests/Fixtures/AbilitiesWithDuplicateValues/BatDuplicatedAbility.php
+++ b/tests/Fixtures/AbilitiesWithDuplicateValues/BatDuplicatedAbility.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace BinaryCats\Rbac\Tests\Fixtures\AbilitiesWithDuplicateValues;
+
+enum BatDuplicatedAbility: string
+{
+    case One = 'una';
+    case Tres = 'tres';
+}

--- a/tests/Fixtures/AbilitiesWithDuplicateValues/BatDuplicatedAbility.php
+++ b/tests/Fixtures/AbilitiesWithDuplicateValues/BatDuplicatedAbility.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace BinaryCats\Rbac\Tests\Fixtures\AbilitiesWithDuplicateValues;
+namespace BinaryCats\LaravelRbac\Tests\Fixtures\AbilitiesWithDuplicateValues;
 
 enum BatDuplicatedAbility: string
 {

--- a/tests/Fixtures/AbilitiesWithDuplicateValues/FooDuplicatedAbility.php
+++ b/tests/Fixtures/AbilitiesWithDuplicateValues/FooDuplicatedAbility.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace BinaryCats\Rbac\Tests\Fixtures\AbilitiesWithDuplicateValues;
+namespace BinaryCats\LaravelRbac\Tests\Fixtures\AbilitiesWithDuplicateValues;
 
 enum FooDuplicatedAbility: string
 {

--- a/tests/Fixtures/AbilitiesWithDuplicateValues/FooDuplicatedAbility.php
+++ b/tests/Fixtures/AbilitiesWithDuplicateValues/FooDuplicatedAbility.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace BinaryCats\Rbac\Tests\Fixtures\AbilitiesWithDuplicateValues;
+
+enum FooDuplicatedAbility: string
+{
+    case One = 'una';
+    case Two = 'otra';
+}

--- a/tests/Fixtures/FooNamedRole.php
+++ b/tests/Fixtures/FooNamedRole.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace BinaryCats\Rbac\Tests\Fixtures;
+namespace BinaryCats\LaravelRbac\Tests\Fixtures;
 
-use BinaryCats\Rbac\DefinedRole;
+use BinaryCats\LaravelRbac\DefinedRole;
 
 class FooNamedRole extends DefinedRole
 {

--- a/tests/Fixtures/FooRole.php
+++ b/tests/Fixtures/FooRole.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace BinaryCats\Rbac\Tests\Fixtures;
+namespace BinaryCats\LaravelRbac\Tests\Fixtures;
 
-use BinaryCats\Rbac\DefinedRole;
-use BinaryCats\Rbac\Tests\Fixtures\Abilities\FooAbility;
+use BinaryCats\LaravelRbac\DefinedRole;
+use BinaryCats\LaravelRbac\Tests\Fixtures\Abilities\FooAbility;
 
 class FooRole extends DefinedRole
 {

--- a/tests/Fixtures/RbacResetJob.php
+++ b/tests/Fixtures/RbacResetJob.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace BinaryCats\Rbac\Tests\Fixtures;
+namespace BinaryCats\LaravelRbac\Tests\Fixtures;
 
 use Illuminate\Bus\Queueable;
 use Illuminate\Foundation\Bus\Dispatchable;

--- a/tests/Jobs/FlushPermissionCacheTest.php
+++ b/tests/Jobs/FlushPermissionCacheTest.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace BinaryCats\Rbac\Tests\Jobs;
+namespace BinaryCats\LaravelRbac\Tests\Jobs;
 
-use BinaryCats\Rbac\Jobs\FlushPermissionCache;
-use BinaryCats\Rbac\Tests\TestCase;
+use BinaryCats\LaravelRbac\Jobs\FlushPermissionCache;
+use BinaryCats\LaravelRbac\Tests\TestCase;
 use Illuminate\Support\Facades\Cache;
 use Mockery\MockInterface;
 use PHPUnit\Framework\Attributes\Test;

--- a/tests/Jobs/ResetPermissionsTest.php
+++ b/tests/Jobs/ResetPermissionsTest.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace BinaryCats\Rbac\Tests\Jobs;
+namespace BinaryCats\LaravelRbac\Tests\Jobs;
 
-use BinaryCats\Rbac\Actions\StorePermission;
-use BinaryCats\Rbac\DiscoverAbilities;
-use BinaryCats\Rbac\Jobs\ResetPermissions;
-use BinaryCats\Rbac\Tests\TestCase;
+use BinaryCats\LaravelRbac\Actions\StorePermission;
+use BinaryCats\LaravelRbac\DiscoverAbilities;
+use BinaryCats\LaravelRbac\Jobs\ResetPermissions;
+use BinaryCats\LaravelRbac\Tests\TestCase;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Str;
 use PHPUnit\Framework\Attributes\Test;
@@ -21,7 +21,7 @@ class ResetPermissionsTest extends TestCase
                 ->replaceFirst($basePath, '')
                 ->trim(DIRECTORY_SEPARATOR)
                 ->after('/tests/')
-                ->prepend('BinaryCats/Rbac/Tests/')
+                ->prepend('BinaryCats/LaravelRbac/Tests/')
                 ->replaceLast('.php', '')
                 ->replace(DIRECTORY_SEPARATOR, '\\')
                 ->toString();

--- a/tests/Jobs/SyncDefinedRolesTest.php
+++ b/tests/Jobs/SyncDefinedRolesTest.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace BinaryCats\Rbac\Tests\Jobs;
+namespace BinaryCats\LaravelRbac\Tests\Jobs;
 
-use BinaryCats\Rbac\Actions\SyncDefinedRole;
-use BinaryCats\Rbac\Jobs\SyncDefinedRoles;
-use BinaryCats\Rbac\Tests\Fixtures\FooNamedRole;
-use BinaryCats\Rbac\Tests\Fixtures\FooRole;
-use BinaryCats\Rbac\Tests\TestCase;
+use BinaryCats\LaravelRbac\Actions\SyncDefinedRole;
+use BinaryCats\LaravelRbac\Jobs\SyncDefinedRoles;
+use BinaryCats\LaravelRbac\Tests\Fixtures\FooNamedRole;
+use BinaryCats\LaravelRbac\Tests\Fixtures\FooRole;
+use BinaryCats\LaravelRbac\Tests\TestCase;
 use PHPUnit\Framework\Attributes\Test;
 
 class SyncDefinedRolesTest extends TestCase

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace BinaryCats\Rbac\Tests;
+namespace BinaryCats\LaravelRbac\Tests;
 
-use BinaryCats\Rbac\RbacServiceProvider;
+use BinaryCats\LaravelRbac\RbacServiceProvider;
 use Orchestra\Testbench\TestCase as Orchestra;
 use Spatie\CollectionMacros\CollectionMacroServiceProvider;
 use Spatie\Permission\PermissionServiceProvider;


### PR DESCRIPTION
- Add RBAC package registration and service binding
- Refactor rbacContainsDuplicateAbilities method signature
- Add test for throwing duplicate permission exception
- Update composer.json with Laravel 11 enum-backed RBAC
- Update namespace from BinaryCats\Rbac to BinaryCats\LaravelRbac
- Enhance Laravel 11 with opinionated extension
